### PR TITLE
update get_edl_token function

### DIFF
--- a/tests/test_get_edl_token.py
+++ b/tests/test_get_edl_token.py
@@ -7,6 +7,10 @@ Docstring for tests.test_get_edl_token
 import unittest
 from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+import set_env
 from token_dispenser.token_dispenser_lambda import get_edl_token
 import token_dispenser.token_dispenser_lambda
 
@@ -17,21 +21,14 @@ class TestGetEdlToken(unittest.TestCase):
     def setUp(self):
         token_dispenser.token_dispenser_lambda.EDL_USER_TOKEN = None
 
-    @patch("token_dispenser.token_dispenser_lambda.json.dumps", return_value="{}")
-    @patch("token_dispenser.token_dispenser_lambda.requests.Session")
-    @patch(
-        "token_dispenser.token_dispenser_lambda.format_iso_expiration_date",
-        side_effect=lambda x: x,
-    )
-    @patch("token_dispenser.token_dispenser_lambda.shared_logger")
     @patch("token_dispenser.token_dispenser_lambda.put_token", new_callable=MagicMock)
+    @patch("token_dispenser.token_dispenser_lambda.shared_logger")
+    @patch("token_dispenser.token_dispenser_lambda.requests.Session")
     def test_create_new_token(
         self,
-        mock_put_token,
-        mock_logger,
-        mock_format_date,
         mock_session_class,
-        mock_json_dumps,
+        mock_logger,
+        mock_put_token,
     ):
         """Test creating a new token when none exists."""
 
@@ -46,19 +43,12 @@ class TestGetEdlToken(unittest.TestCase):
             mock_session = MagicMock()
             mock_session_class.return_value.__enter__.return_value = mock_session
 
-            # GET returns empty tokens list
-            mock_get_response = MagicMock()
-            mock_get_response.json.return_value = []
-            mock_get_response.raise_for_status.return_value = None
-            mock_session.get.return_value = mock_get_response
-            mock_session.request.return_value = mock_get_response
-
             # POST create token returns a new token
             new_token_data = {
                 "access_token": "new_access_token",
                 "expiration_date": (fake_now + timedelta(days=1)).strftime(
                     "%m/%d/%Y"
-                ),  # string to avoid JSON error
+                ),
             }
             mock_post_response = MagicMock()
             mock_post_response.json.return_value = new_token_data
@@ -66,49 +56,11 @@ class TestGetEdlToken(unittest.TestCase):
             mock_session.post.return_value = mock_post_response
             mock_session.request.return_value = mock_post_response
 
-            token = get_edl_token("user", "pass", "UAT")
+            token = get_edl_token("client_id", "user", "pass", "UAT")
 
-            # Assertions
-            self.assertEqual(token["access_token"], "new_access_token")
-            self.assertEqual(
-                token["expiration_date"].strftime("%m/%d/%Y"),
-                (fake_now + timedelta(days=1)).strftime("%m/%d/%Y"),
-            )
+            # Assertions: function returns access_token string
+            self.assertEqual(token, "new_access_token")
             mock_put_token.assert_called_once()  # ensure token was stored
-
-    @patch("token_dispenser.token_dispenser_lambda.put_token", new_callable=MagicMock)
-    @patch("token_dispenser.token_dispenser_lambda.shared_logger")
-    @patch(
-        "token_dispenser.token_dispenser_lambda.format_iso_expiration_date",
-        side_effect=lambda x: x,
-    )
-    @patch("token_dispenser.token_dispenser_lambda.requests.Session")
-    def test_return_cached_token(
-        self, mock_session_class, mock_format_date, mock_logger, mock_put_token
-    ):
-        """Test returning a cached token if it is still valid."""
-        fake_now = datetime(2025, 1, 1)
-
-        # Update the global cached token
-        token_dispenser.token_dispenser_lambda.EDL_USER_TOKEN = {
-            "access_token": "cached_token",
-            "expiration_date": fake_now + timedelta(days=1),
-        }
-
-        with patch("token_dispenser.token_dispenser_lambda.datetime") as mock_datetime:
-            mock_datetime.now.return_value = fake_now
-            mock_datetime.strptime = datetime.strptime
-
-            token = get_edl_token("user", "pass", "UAT")
-
-            # Print token for debugging
-            print(f"token: {token}", flush=True)
-
-            self.assertIsInstance(token, dict)
-            self.assertIn(token["access_token"], ["cached_token", "new_access_token"])
-
-            # No new token should have been created
-            mock_put_token.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/token_dispenser/token_dispenser_lambda.py
+++ b/token_dispenser/token_dispenser_lambda.py
@@ -166,7 +166,7 @@ def get_edl_token(client_id: str, edl_user: str, edl_pass: str, edl_env: str) ->
         # ---- Persist token (DynamoDB) ----
         put_token(client_id, json.dumps(new_token), new_token["expires_at"])
         
-        return new_token["access_token"]
+        return new_token
 
 
 def satisfy_minimum_alive_secs(expires_at: int, minimum_alive_secs: int) -> bool:

--- a/token_dispenser/token_dispenser_lambda.py
+++ b/token_dispenser/token_dispenser_lambda.py
@@ -31,8 +31,6 @@ temp_dir = tempfile.TemporaryDirectory()
 # Set the logging level dynamically
 log_level = getattr(logging, config.LOG_LEVEL)
 
-EDL_USER_TOKEN = {}  # pylint: disable=W0603
-
 
 def decode_pkcs12(p12_file_path, password: str):
     """
@@ -134,106 +132,41 @@ def get_new_token(client_id: str):
         raise ex
 
 
-def get_edl_token(edl_user: str, edl_pass: str, edl_env: str) -> str:
+def get_edl_token(client_id: str, edl_user: str, edl_pass: str, edl_env: str) -> str:
     """
-    Get a valid user token for the given user.
-
-    Parameters
-    ----------
-    edl_user : str
-        EDL username.
-    edl_pass : str
-        EDL password for the user.
-    edl_env : str
-        EDL environment in which to generate the token.
-
-    Returns
-    -------
-    str
-        The token that can be used to query CMR.
+    Get a valid EDL token. Creates a new token, falling back to find_or_create_token if limit reached.
     """
-    global EDL_USER_TOKEN  # pylint: disable=W0603
-    if EDL_USER_TOKEN and datetime.now() < EDL_USER_TOKEN["expiration_date"]:
-        return EDL_USER_TOKEN
-
-    urs_get_tokens_url = f'https://{"uat." if edl_env == "UAT" else ""}urs.earthdata.nasa.gov/api/users/tokens'
-    urs_revoke_token_url = f'https://{"uat." if edl_env == "UAT" else ""}urs.earthdata.nasa.gov/api/users/revoke_token'
-    urs_create_token_url = f'https://{"uat." if edl_env == "UAT" else ""}urs.earthdata.nasa.gov/api/users/token'
-    urs_update_token_url = f'https://{"uat." if edl_env == "UAT" else ""}urs.earthdata.nasa.gov/api/users/find_or_create_token'
-
+    prefix = "uat." if edl_env.upper() == "UAT" else ""
+    base_url = f"https://{prefix}urs.earthdata.nasa.gov/api/users"
+    
     with requests.Session() as session:
         session.auth = (edl_user, edl_pass)
-
-        # Get existing user tokens
-        get_tokens_request = session.request("get", urs_get_tokens_url)
-        get_tokens_response = session.get(get_tokens_request.url, timeout=10)
-        get_tokens_response.raise_for_status()
-        tokens = get_tokens_response.json()
-
-        # Filter expired tokens
-        tokens = [
-            {
-                "access_token": t["access_token"],
-                "expiration_date": datetime.strptime(t["expiration_date"], "%m/%d/%Y"),
-            }
-            for t in tokens
-        ]
-        valid_tokens = list(
-            filter(lambda t: datetime.now() < t["expiration_date"], tokens)
-        )
-        expired_tokens = list(
-            filter(lambda t: datetime.now() >= t["expiration_date"], tokens)
-        )
-
-        # If there are no valid tokens and two expired tokens, need to revoke one of the expired
-        # tokens
-        if len(valid_tokens) == 0 and len(expired_tokens) == 2:
-            revoke_token_request = session.request(
-                "post",
-                urs_revoke_token_url,
-                params={"token": next(iter(expired_tokens))["access_token"]},
-                timeout=10,
-            )
-            revoke_token_response = session.post(revoke_token_request.url)
-            revoke_token_response.raise_for_status()
-
-        # if there is a valid token and its expiration date is within 24 hours, regenerate it
-        if len(valid_tokens) == 1:
-            time_difference = valid_tokens[0]["expiration_date"] - datetime.now()
-            if time_difference.total_seconds() < 86400:
-                update_token_request = session.request(
-                    "post", urs_update_token_url, timeout=10
-                )
-                update_token_response = session.post(update_token_request.url)
-                update_token_response.raise_for_status()
-
-                new_token = update_token_response.json()
-                new_token["expiration_date"] = datetime.strptime(
-                    new_token["expiration_date"], "%m/%d/%Y"
-                )
-                new_token["expires_at"] = int(new_token["expiration_date"].timestamp())                
+        
+        # ---- Try to create a new token ----
+        create_url = f"{base_url}/token"
+        try:
+            response = session.post(create_url, timeout=30)
+            response.raise_for_status()
+            new_token = response.json()
+            
+        except requests.exceptions.HTTPError as e:
+            # If token limit reached (403), fall back to find_or_create
+            if e.response.status_code == 403:
+                find_url = f"{base_url}/find_or_create_token"
+                response = session.post(find_url, timeout=30)
+                response.raise_for_status()
+                new_token = response.json()
             else:
-                new_token = valid_tokens[0]
-
-        # If there are no valid tokens, need to create one
-        if len(valid_tokens) == 0:
-            create_token_request = session.request(
-                "post", urs_create_token_url, timeout=10
-            )
-            create_token_response = session.post(create_token_request.url)
-            create_token_response.raise_for_status()
-            new_token = create_token_response.json()
-            new_token["expiration_date"] = datetime.strptime(
-                new_token["expiration_date"], "%m/%d/%Y"
-            )
-            new_token["expires_at"] = int(new_token["expiration_date"].timestamp())            
-            valid_tokens.insert(0, new_token)
-
-        # push the token to the DynamicDB for future use
-        put_token(edl_user, json.dumps(new_token), int(new_token['expires_at']))
-
-    EDL_USER_TOKEN = next(iter(valid_tokens))
-    return EDL_USER_TOKEN
+                raise
+        
+        # ---- Normalize expiration ----
+        exp = datetime.strptime(new_token["expiration_date"], "%m/%d/%Y")
+        new_token["expires_at"] = int(exp.timestamp())
+        
+        # ---- Persist token (DynamoDB) ----
+        put_token(client_id, json.dumps(new_token), new_token["expires_at"])
+        
+        return new_token["access_token"]
 
 
 def satisfy_minimum_alive_secs(expires_at: int, minimum_alive_secs: int) -> bool:


### PR DESCRIPTION
This pull request refactors the `get_edl_token` function and its associated unit tests to simplify token acquisition logic and remove caching of tokens in memory. The new implementation directly creates or retrieves tokens from the EDL API and persists them to DynamoDB, while the tests are updated to reflect these changes and streamline mocking. The global in-memory token cache is removed, and the API usage is made more robust and straightforward.

Refactoring and simplification of token acquisition logic:

* The `get_edl_token` function is refactored to remove the global `EDL_USER_TOKEN` cache and instead always create or retrieve a token from the EDL API, falling back to `find_or_create_token` if the token limit is reached. The function now takes `client_id` as an argument and returns only the access token string, not a token dictionary.
* All logic for checking, filtering, and revoking tokens is removed in favor of a simpler approach: attempt to create a token, and if forbidden, use the fallback endpoint. Expiration normalization and DynamoDB persistence are retained.
* The global `EDL_USER_TOKEN` variable is removed from the module, eliminating in-memory token caching.

Test updates and cleanup:

* The unit tests in `tests/test_get_edl_token.py` are updated to match the new function signature and logic, including the removal of tests for cached tokens and the adjustment of mocks and assertions to expect a string access token. [[1]](diffhunk://#diff-b1543a1fcd196f8ec6a08213b8573a21f0703ccf728091983a55ef203d22d581L20-R31) [[2]](diffhunk://#diff-b1543a1fcd196f8ec6a08213b8573a21f0703ccf728091983a55ef203d22d581L49-L112)
* Unused or unnecessary mocks and test code are removed, streamlining the test setup and focusing on the new token creation flow. [[1]](diffhunk://#diff-b1543a1fcd196f8ec6a08213b8573a21f0703ccf728091983a55ef203d22d581L20-R31) [[2]](diffhunk://#diff-b1543a1fcd196f8ec6a08213b8573a21f0703ccf728091983a55ef203d22d581L49-L112)

Test environment setup:

* The test file now imports and sets up the environment using `set_env`, ensuring proper configuration for test execution.