### PR TITLE
update get_edl_token function call

### DIFF
--- a/token_dispenser/token_dispenser_lambda.py
+++ b/token_dispenser/token_dispenser_lambda.py
@@ -262,7 +262,7 @@ def handler(event, context):
         # save to dynamoDB and return new token
 
         if event.get("action") == "edl":        
-            token_json = get_edl_token(client_id, event.get("edl_pass"), event.get("cmr_env"))
+            token_json = get_edl_token(client_id, event.get("edl_user"), event.get("edl_pass"), event.get("cmr_env"))
         else:
             token_json = get_new_token(client_id)
         return token_json


### PR DESCRIPTION
This pull request updates the `handler` function in `token_dispenser_lambda.py` to correctly pass the EDL username when requesting a token. This change ensures that the `get_edl_token` function receives all necessary parameters for authentication.

Authentication parameter fix:

* Updated the call to `get_edl_token` to include the `edl_user` parameter from the event, ensuring proper EDL authentication.