### PR TITLE
Feature/update client

### DIFF
--- a/token_dispenser/token_dispenser_lambda.py
+++ b/token_dispenser/token_dispenser_lambda.py
@@ -216,11 +216,7 @@ def handler(event, context):
     :return: Exception or json which represents a token structure
     """
     
-    # Determine client_id based on action(or lack thereof)
-    if event.get("action") == "edl":
-        client_id = event.get("edl_user")
-    else:
-        client_id = event.get('client_id')
+    client_id = event.get('client_id')
 
     if not client_id or client_id.strip() == "":
         raise RuntimeError('client_id is a required field')

--- a/token_dispenser/token_dispenser_lambda.py
+++ b/token_dispenser/token_dispenser_lambda.py
@@ -262,7 +262,7 @@ def handler(event, context):
         # save to dynamoDB and return new token
 
         if event.get("action") == "edl":        
-            token_json = get_edl_token(client_id, event.get("edl_pass"), event.get("cmr_env"))
+            token_json = get_edl_token(client_id, event.get("edl_user"), event.get("edl_pass"), event.get("cmr_env"))
         else:
             token_json = get_new_token(client_id)
         return token_json


### PR DESCRIPTION
This pull request simplifies the logic for determining the `client_id` in the `handler` function of `token_dispenser/token_dispenser_lambda.py`. The special handling for the `"edl"` action has been removed, so now `client_id` is always taken directly from the event.

* Simplified `client_id` assignment logic in the `handler` function by removing conditional logic for the `"edl"` action; `client_id` is now always set from `event.get('client_id')`.